### PR TITLE
Add public endpoint to retrieve all anomalies with related camera and organization information

### DIFF
--- a/controllers/publicController.js
+++ b/controllers/publicController.js
@@ -1,0 +1,62 @@
+const { Anomaly, Camera, Organization } = require('../models');
+
+/**
+ * Get all anomalies across all organizations
+ * This endpoint is publicly accessible without authentication
+ */
+const getAllAnomalies = async (req, res) => {
+    try {
+        // Fetch all anomalies with their related cameras and organization information
+        const anomalies = await Anomaly.findAll({
+            include: [
+                { 
+                    model: Camera,
+                    attributes: ['cameraId', 'location', 'ipAddress', 'cameraType', 'status']
+                },
+                {
+                    model: Organization,
+                    attributes: ['orgId', 'name']
+                }
+            ]
+        });
+
+        // Return formatted response
+        res.status(200).json({
+            count: anomalies.length,
+            anomalies: anomalies.map(anomaly => ({
+                anomalyId: anomaly.anomalyId,
+                title: anomaly.title,
+                description: anomaly.description,
+                criticality: anomaly.criticality,
+                startTime: anomaly.startTime,
+                endTime: anomaly.endTime,
+                daysOfWeek: anomaly.daysOfWeek,
+                modelName: anomaly.modelName,
+                status: anomaly.status,
+                createdAt: anomaly.createdAt,
+                updatedAt: anomaly.updatedAt,
+                organization: anomaly.Organization ? {
+                    id: anomaly.Organization.orgId,
+                    name: anomaly.Organization.name
+                } : null,
+                cameras: anomaly.Cameras ? anomaly.Cameras.map(camera => ({
+                    cameraId: camera.cameraId,
+                    location: camera.location,
+                    ipAddress: camera.ipAddress,
+                    cameraType: camera.cameraType,
+                    status: camera.status
+                })) : []
+            }))
+        });
+    } catch (error) {
+        console.error('[ERROR] Fetching all anomalies:', error);
+        res.status(500).json({ 
+            message: 'Failed to fetch anomalies', 
+            error: error.message 
+        });
+    }
+};
+
+module.exports = { 
+    getAllAnomalies 
+};

--- a/routes/publicRoutes.js
+++ b/routes/publicRoutes.js
@@ -1,0 +1,7 @@
+const express = require('express');
+const router = express.Router();
+const { getAllAnomalies } = require('../controllers/publicController');
+
+router.get('/anomalies', getAllAnomalies);
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -15,6 +15,7 @@ app.use("/api/auth", require("./routes/authRoutes"));
 app.use("/api/admin", require("./routes/adminRoutes"));
 app.use("/api/organization", require("./routes/organizationRoutes"));
 app.use("/api/analytics", require("./routes/analyticsRoutes"));
+app.use("/api/public", require("./routes/publicRoutes")); // Public routes without authentication
 
 // Initialize database connection
 const initializeDb = async () => {


### PR DESCRIPTION
This pull request introduces a new publicly accessible API endpoint to fetch all anomalies, along with their associated cameras and organization details. The changes include adding a new controller, route, and integration into the server.

### New Public API Feature:

* **Controller Implementation**: Added a `getAllAnomalies` function in `controllers/publicController.js` to fetch all anomalies from the database, including related camera and organization information. The response is formatted to include detailed anomaly, camera, and organization attributes.
* **Route Definition**: Created a new route in `routes/publicRoutes.js` to map the `/anomalies` endpoint to the `getAllAnomalies` controller function.
* **Server Integration**: Registered the `publicRoutes` in `server.js` under the `/api/public` path, enabling public access to the new endpoint without authentication.